### PR TITLE
Fix confusing indentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ module.exports = {
     ...
     module: {
         rules: [{
-        test: /\.less$/,
-        use: ["style-loader", "css-loader", "less-loader"]
-    }]
-}
+            test: /\.less$/,
+            use: ["style-loader", "css-loader", "less-loader"]
+        }]
+    }
 };
 ```
 


### PR DESCRIPTION
I've copied the wrong part of the webpack.config.js snippet too many times because of it. This might have happened to the others.